### PR TITLE
  Fix stat showing bogus st_link field.

### DIFF
--- a/lib/9pfs/9pfs_vnops.c
+++ b/lib/9pfs/9pfs_vnops.c
@@ -554,6 +554,8 @@ static int uk_9pfs_getattr(struct vnode *vp, struct vattr *attr)
 	attr->va_mode = uk_9pfs_posix_mode_from_mode(stat.mode);
 	attr->va_nodeid = vp->v_ino;
 	attr->va_size = stat.length;
+	/* Initialize va_nlink */
+	attr->va_nlink = 1;
 
 	attr->va_atime.tv_sec = stat.atime;
 	attr->va_atime.tv_nsec = 0;

--- a/lib/nolibc/include/nolibc-internal/shareddefs.h
+++ b/lib/nolibc/include/nolibc-internal/shareddefs.h
@@ -109,7 +109,7 @@ typedef __u64 ino_t;
 #endif
 
 #if defined(__NEED_nlink_t) && !defined(__DEFINED_nlink_t)
-typedef __u32 nlink_t;
+typedef __u64 nlink_t;
 #define __DEFINED_nlink_t
 #endif
 

--- a/lib/posix-sysinfo/include/sys/sysinfo.h
+++ b/lib/posix-sysinfo/include/sys/sysinfo.h
@@ -46,7 +46,7 @@ struct sysinfo {
 	unsigned long totalhigh;
 	unsigned long freehigh;
 	unsigned mem_unit;
-	char __reserved[256];
+	//char __reserved[256];
 };
 
 int sysinfo (struct sysinfo *);

--- a/lib/vfscore/include/vfscore/vnode.h
+++ b/lib/vfscore/include/vfscore/vnode.h
@@ -97,7 +97,7 @@ struct vattr {
 	unsigned int	va_mask;
 	enum vtype	va_type;	/* vnode type */
 	mode_t		va_mode;	/* file access mode */
-	nlink_t		va_nlink;
+	__u32           va_nlink;
 	uid_t		va_uid;
 	gid_t		va_gid;
 	dev_t           va_fsid;        /* id of the underlying filesystem */


### PR DESCRIPTION
  1. Initialize va_nlink in 9pfs (in funtion uk_9pfs_getattr)
  2. Set ntlink_t type to u64 (libc expects ntlink_t to be 64 bits)
  3. Set va_link field from struct vattr to u32 (previously ntlink_t) to preserve platform requirements (va_link must be 32 bits).

  This fixes issue with bogus stat link field on 9pfs and also fixes the .read issue when running sqlite3.

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [ ] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [ ] Tested your changes against relevant architectures and platforms;
 - [ ] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Base target

 - Architecture(s): [e.g. `x86_64` or N/A]
 - Platform(s): [e.g. `kvm`, `xen` or N/A]
 - Application(s): [e.g. `app-python3` or N/A]


### Additional configuration

<!--
Please specify any additional configuration which is needed for this feature to
work or any new configuration parameters which are introduced by this PR.  This
will help during the review process.  For example:

 - `CONFIG_LIBUKDEBUG=y`

-->

### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
