### PR TITLE
lib/uktime: Add clock_getres syscall

### DIFF
--- a/lib/uktime/time.c
+++ b/lib/uktime/time.c
@@ -140,10 +140,31 @@ UK_SYSCALL_R_DEFINE(int, gettimeofday, struct timeval *, tv, void *, tz)
 }
 
 UK_SYSCALL_R_DEFINE(int, clock_getres, clockid_t, clk_id,
-		    struct timespec *, res)
+		    struct timespec *, tp)
 {
-	UK_WARN_STUBBED();
+	int error;
+
+	if (!tp) {
+		error = EFAULT;
+		goto out_error;
+	}
+
+	switch (clk_id) {
+	case CLOCK_MONOTONIC:
+	case CLOCK_MONOTONIC_COARSE:
+	case CLOCK_REALTIME:
+		tp->tv_sec = 0;
+		tp->tv_nsec = UKPLAT_TIME_TICK_NSEC;
+		break;
+	default:
+		error = EINVAL;
+		goto out_error;
+	}
+
 	return 0;
+
+out_error:
+	return -error;
 }
 
 UK_SYSCALL_R_DEFINE(int, clock_gettime, clockid_t, clk_id, struct timespec*, tp)


### PR DESCRIPTION

<!--

Thank you for opening a new PR to the Unikraft Open Source Project!  We welcome
new changes, features, fixes, and more!  Please fill in this form to indicate
the status of your PR.  Please ensure you have read the contribution guidelines
before opening a new PR as this will cover the PR process:

  https://docs.unikraft.org/contribute.html

-->

### Prerequisite checklist

<!--
Please mark items appropriately:
-->

 - [x] Read the [contribution guidelines](https://docs.unikraft.org/contribute.html) regarding submitting new changes to the project;
 - [x] Tested your changes against relevant architectures and platforms;
 - [x] Ran the [`checkpatch.pl`](https://github.com/unikraft/unikraft/blob/staging/support/scripts/checkpatch.pl) on your commit series before opening this PR;
 - [ ] Updated relevant documentation.


### Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
The clock_getres syscall returns the clock resolution,
stored in the `struct timespec *tp` argument.
The resolution is saved in `UKPLAT_TIME_TICK_NSEC`,
defined [here](https://github.com/unikraft/unikraft/blob/staging/include/uk/plat/time.h#L53) as `UKARCH_NSEC_PER_SEC / CONFIG_HZ`
(i.e. nanoseconds passed between consecutive clock ticks).

Solves issues [#496](https://github.com/unikraft/unikraft/issues/496) and [#495](https://github.com/unikraft/unikraft/issues/495).

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>

